### PR TITLE
Added support for Prometheus Metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring-boot.bom.version>1.5.8.Final-redhat-1</spring-boot.bom.version>
         <springboot.version>1.5.8.RELEASE</springboot.version>
+        <springboot.metrics.version>0.5.1.RELEASE</springboot.metrics.version>
+        <prometheus.client.version>0.1.0</prometheus.client.version>
     </properties>
 
     <dependencyManagement>
@@ -42,6 +44,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.metrics</groupId>
+            <artifactId>spring-metrics</artifactId>
+            <version>${springboot.metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>${prometheus.client.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/hello/Application.java
+++ b/src/main/java/hello/Application.java
@@ -2,8 +2,10 @@ package hello;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.metrics.export.prometheus.EnablePrometheusMetrics;
 
 @SpringBootApplication
+@EnablePrometheusMetrics
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/hello/GreetingController.java
+++ b/src/main/java/hello/GreetingController.java
@@ -1,9 +1,11 @@
 package hello;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.metrics.instrument.Counter;
+import org.springframework.metrics.instrument.MeterRegistry;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,11 +16,16 @@ public class GreetingController {
     private static final String template = "Hello, %s!";
     private static final String welcome = "This is my webservice!";
     private static final List<String> paths = Arrays.asList("/", "/greeting", "/hostinfo");
-    private final AtomicLong counter = new AtomicLong();
+    private final Counter counter;
+
+    public GreetingController(MeterRegistry registry) {
+       counter = registry.counter("greeting_counter");
+    }
 
     @RequestMapping("/greeting")
     public Greeting greeting(@RequestParam(value="name", defaultValue="World") String name) {
-        return new Greeting(counter.incrementAndGet(),
+        counter.increment();
+        return new Greeting((int)counter.count(),
                             String.format(template, name));
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 endpoints.shutdown.enabled=true
+endpoints.prometheus.sensitive=false


### PR DESCRIPTION
Added support for exposing Prometheus compatible metrics

1. Metrics are exposed at `/prometheus`
2. Default JVM metrics exposed
3. Added custom `greeting_counter` metric

cc: @etsauer @redhat-cop/developer-workflow 