### PR TITLE
Bump Jackson version 2.9.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>2.9.9.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -64,7 +69,7 @@
             <version>${springfox-version}</version>
         </dependency>
         -->
-        
+
         <!--
         <dependency>
             <groupId>io.springfox</groupId>
@@ -73,7 +78,7 @@
         </dependency>
         -->
         <!-- Guava version override for https://github.com/springfox/springfox/issues/2795 -->
-        
+
         <!--
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-databind</artifactId>
-              <version>2.9.9.1</version>
+              <version>2.9.9.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Bump Jackson version 2.9.9.3 to resolve CVE errors.  This will resolve issue #32 