### PR TITLE
Use of spring-restdocs/asciidoctor instead of swagger/springfox.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <spring-boot.bom.version>2.1.6.SP3-redhat-00001</spring-boot.bom.version>
         <springboot.version>2.1.6.RELEASE</springboot.version>
         <undertow.version>2.0.25.SP1-redhat-00001</undertow.version>
+        <spring.restdocs.version>2.0.3.RELEASE</spring.restdocs.version>
     </properties>
 
     <dependencyManagement>
@@ -75,6 +76,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- spring rest deps -->
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-mockmvc</artifactId>
+            <version>${spring.restdocs.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>
@@ -137,6 +146,33 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html</backend>
+                            <doctype>book</doctype>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-asciidoctor</artifactId>
+                        <version>${spring.restdocs.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/asciidoc/api-guide.adoc
+++ b/src/main/asciidoc/api-guide.adoc
@@ -1,0 +1,83 @@
+= RESTful Notes API Guide
+Spring REST;
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:operation-curl-request-title: Example request
+:operation-http-response-title: Example response
+
+[[overview]]
+= Overview
+
+[[overview-http-verbs]]
+== HTTP verbs
+
+RESTful notes tries to adhere as closely as possible to standard HTTP and REST conventions in its
+use of HTTP verbs.
+
+|===
+| Verb | Usage
+
+| `GET`
+| Used to retrieve a resource
+
+| `POST`
+| Used to create a new resource
+
+| `PATCH`
+| Used to update an existing resource, including partial updates
+
+| `DELETE`
+| Used to delete an existing resource
+|===
+
+[[overview-http-status-codes]]
+== HTTP status codes
+
+RESTful notes tries to adhere as closely as possible to standard HTTP and REST conventions in its
+use of HTTP status codes.
+
+|===
+| Status code | Usage
+
+| `200 OK`
+| The request completed successfully
+
+| `201 Created`
+| A new resource has been created successfully. The resource's URI is available from the response's
+`Location` header
+
+| `204 No Content`
+| An update to an existing resource has been applied successfully
+
+| `400 Bad Request`
+| The request was malformed. The response body will include an error providing further information
+
+| `404 Not Found`
+| The requested resource did not exist
+|===
+
+[[greetings-v1]]
+=== Greetings Service (V1)
+
+A `GET` request will display a greeting.
+
+operation::greeting-v1[snippets='response-fields,curl-request,http-response']
+
+[[envinfo-v1]]
+=== Environment Information Service (V1)
+
+A `GET` request will display the current environment information.
+
+operation::envinfo-v1[snippets='request-parameters,response-fields,curl-request,http-response']
+
+
+[[hostname-v1]]
+=== Hostname Service (V1)
+
+A `GET` request will display the current hostname.
+
+operation::hostname-v1[snippets='response-fields,curl-request,http-response']

--- a/src/main/java/openshift/cop/EnvInfo.java
+++ b/src/main/java/openshift/cop/EnvInfo.java
@@ -22,7 +22,7 @@ public class EnvInfo {
 
   public static Map<String,String> mapEnvInfo(String filter) throws IOException {
       Process proc = Runtime.getRuntime().exec("env");
-      Map<String, String> ret = new HashMap<String,String>();
+      Map<String, String> ret = new HashMap<>();
             try (InputStream stream = proc.getInputStream()) {
           try (Scanner s = new Scanner(stream).useDelimiter("\\n")) {
         	  while (s.hasNext())

--- a/src/test/java/hello/ApiDocumentationTest.java
+++ b/src/test/java/hello/ApiDocumentationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hello;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.JUnitRestDocumentation;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.request.RequestDocumentation;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ApiDocumentationTest {
+
+  @Rule
+  public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  private MockMvc mockMvc;
+
+  @Before
+  public void setUp() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+        .apply(documentationConfiguration(this.restDocumentation)).build();
+  }
+
+  @Test
+  public void greetingV1() throws Exception {
+    this.mockMvc
+        .perform(
+            get("/v1/greeting")
+                .header("Origin", "*")
+        )
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello, World!")))
+        .andDo(
+            document("greeting-v1",
+                responseFields(
+                    fieldWithPath("id").description("The number of greetings that have been requested.").type(JsonFieldType.NUMBER),
+                    fieldWithPath("content").description("The content of the greeting.").type(JsonFieldType.STRING)
+                )
+            )
+        );
+  }
+
+  @Test
+  public void hostinfoV1() throws Exception {
+    this.mockMvc
+        .perform(
+            get("/v1/hostinfo")
+                .header("Origin", "*")
+        )
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().string(anything()))
+        .andDo(
+            document("hostname-v1",
+                responseFields(
+                    fieldWithPath("hostname").description("The instance's hostname.").type(JsonFieldType.STRING)
+                )
+            )
+        );
+  }
+
+  @Test
+  public void envInfoV1() throws Exception {
+    this.mockMvc
+        .perform(
+            get("/v1/envinfo")
+                .param("filter", "*")
+                .header("Origin", "*")
+        )
+        .andDo(print()).andExpect(status().isOk())
+        .andExpect(content().string(anything()))
+        .andDo(
+            document("envinfo-v1",
+                requestParameters(
+                    parameterWithName("filter")
+                        .description("A filter for the environment variables. Use * for all variables.")
+                        .optional()
+                )
+            )
+        );
+  }
+
+}

--- a/src/test/java/openshift/cop/ApiDocumentationTest.java
+++ b/src/test/java/openshift/cop/ApiDocumentationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package hello;
+package openshift.cop;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
@@ -24,23 +24,21 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.restdocs.JUnitRestDocumentation;
-import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.payload.PayloadDocumentation;
-import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.containsString;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/openshift/cop/GreetingControllerTest.java
+++ b/src/test/java/openshift/cop/GreetingControllerTest.java
@@ -21,7 +21,7 @@ public class GreetingControllerTest {
 	private MockMvc mockMvc;
 
 	@Test
-	public void testGreeting() throws Exception {
+	public void testGreetingV1() throws Exception {
 		this.mockMvc.perform(get("/v1/greeting").header("Origin", "*")).andDo(print()).andExpect(status().isOk())
 				.andExpect(content().string(containsString("Hello, World!")));
 	}


### PR DESCRIPTION
Saw that you all had to remove springfox due to security vulnerabilities. Did some research, and the latest version of springfox still has the vulnerabilities in question. Fortunately, spring-restdocs has no such issues. This PR is an implementation of rest documentation using spring-restdocs instead of swagger/springfox.