### PR TITLE
Fix repository and plugin URLs and bump versions to latest supported versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot.bom.version>2.1.13.SP3-redhat-00001</spring-boot.bom.version>
+        <spring-boot.bom.version>2.1.13.Final-redhat-00001</spring-boot.bom.version>
         <springboot.version>2.1.13.RELEASE</springboot.version>
         <undertow.version>2.0.28.SP1-redhat-00001</undertow.version>
         <spring.restdocs.version>2.0.3.RELEASE</spring.restdocs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot.bom.version>2.1.6.SP3-redhat-00001</spring-boot.bom.version>
-        <springboot.version>2.1.6.RELEASE</springboot.version>
-        <undertow.version>2.0.25.SP1-redhat-00001</undertow.version>
+        <spring-boot.bom.version>2.1.13.SP3-redhat-00001</spring-boot.bom.version>
+        <springboot.version>2.1.13.RELEASE</springboot.version>
+        <undertow.version>2.0.28.SP1-redhat-00001</undertow.version>
         <spring.restdocs.version>2.0.3.RELEASE</spring.restdocs.version>
     </properties>
 
@@ -180,14 +180,14 @@
         <repository>
             <id>redhat-ga-repository</id>
             <name>Redhat GA Repository</name>
-            <url>https://maven.repository.redhat.com/ga/all/</url>
+            <url>https://maven.repository.redhat.com/ga/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>redhat-ga-repository</id>
             <name>Redhat GA Repository</name>
-            <url>https://maven.repository.redhat.com/ga/all/</url>
+            <url>https://maven.repository.redhat.com/ga/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
#### What does this PR do?
Fix the URL for supported Spring Boot configuration. [1]
Also bump the versions to the latest supported RHAR Spring Boot versions. 

[1] [Configure your applications](https://access.redhat.com/documentation/en-us/red_hat_support_for_spring_boot/2.1/html/spring_boot_2.1.x_runtime_guide/configuring-your-application-to-use-spring-boot_spring-boot)

#### Is there a relevant Issue open for this?
No open issue

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
