### PR TITLE
Upgrade to Spring boot 2.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spring-boot.bom.version>2.1.13.Final-redhat-00001</spring-boot.bom.version>
-        <springboot.version>2.1.13.RELEASE</springboot.version>
+        <snowdrop-dependencies.version>2.2.6.Final-redhat-00001</snowdrop-dependencies.version>
+        <springboot.version>2.2.6.RELEASE</springboot.version>
         <undertow.version>2.0.28.SP1-redhat-00001</undertow.version>
         <spring.restdocs.version>2.0.3.RELEASE</spring.restdocs.version>
     </properties>
@@ -23,9 +23,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>me.snowdrop</groupId>
-                <artifactId>spring-boot-bom</artifactId>
-                <version>${spring-boot.bom.version}</version>
+                <groupId>dev.snowdrop</groupId>
+                <artifactId>snowdrop-dependencies</artifactId>
+                <version>${snowdrop-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
**What does this PR do?**
Changes applied are coming from the runtime guide, basically using the newest dependencies for Spring Boot 2.2.6.

[RHSA-2020:2252 - Security Advisory](https://access.redhat.com/errata/RHSA-2020:2252)
[Spring boot 2.2.6 runtime guide](https://access.redhat.com/documentation/en-us/red_hat_support_for_spring_boot/2.2/html/spring_boot_runtime_guide/configuring-your-application-to-use-spring-boot_spring-boot)
[Red Hat support for Spring Boot: 2.2.6 Component Details](https://access.redhat.com/articles/5099911)

**Is there a relevant Issue open for this?**
No open issue

**Who would you like to review this?**

cc: @redhat-cop/containers-approvers
