### PR TITLE
FIX: update GH workflow syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Test Maven Build
-on: push, pull_request
+on:
+  - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
This should fix the following issue
> [Invalid workflow file: .github/workflows/main.yml#L1](https://github.com/redhat-cop/spring-rest/actions/runs/2884733530/workflow)
`push, pull_request` is not a valid event name